### PR TITLE
Directly spawn python process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,4 @@ EXPOSE 5050
 WORKDIR /opt
 
 ## Run Couchpotato
-ENTRYPOINT python CouchPotatoServer/CouchPotato.py
+ENTRYPOINT ["python", "CouchPotatoServer/CouchPotato.py"]


### PR DESCRIPTION
bypassing bash as stated here https://docs.docker.com/reference/builder/#exec-form-entrypoint-example
