### PR TITLE
Move --restart=always

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 ## Base image to use
-FROM ubuntu:14.04
+FROM centos:centos7
 
 ## Maintainer info
-MAINTAINER razorgirl <https://github.com/razorgirl>
+MAINTAINER mchlumsky <martin.chlumsky@gmail.com>
 
 ## Update base image
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get dist-upgrade -y
+RUN yum update -y
 
 ## Install prerequisites
-RUN apt-get install -y python git-core
+RUN yum install -y git
 
 ## Install Couchpotato
 RUN cd /opt && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-couchpotato
 
-Dockerfile to set up a Couchpotato container
+Dockerfile to set up a Couchpotato container (based on CentOS 7)
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As CouchPotato routinely updates itself, the Docker container will stop to run a
 
 Starting with Docker 1.3, you can now use the `--restart=always` flag to let Docker handle the automatic restart of the container.
 
-    docker run -d -p 5050:5050 -v <LOCAL_MOVIES_FOLDER>:/movies --name couchpotato apps/couchpotato --restart=always
+    docker run -d -p 5050:5050 -v <LOCAL_MOVIES_FOLDER>:/movies --restart=always --name couchpotato apps/couchpotato
 
 Thanks to Ashex1 for the hint!
 


### PR DESCRIPTION
The --restart=always option needs to be placed before the docker container name.
Otherwise you get this:

00:19 $ docker logs couchpotato
usage: CouchPotato.py [-h] [--data_dir DATA_DIR] [--config_file CONFIG_FILE]
                      [--debug] [--console_log] [--quiet] [--daemon]
                      [--pid_file PID_FILE]
CouchPotato.py: error: unrecognized arguments: --restart=always
