### PR TITLE
Set python to use UTF-8 instead of ascii

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM alpine
 ## Maintainer info
 MAINTAINER razorgirl <https://github.com/razorgirl>
 
+# set python to use utf-8 rather than ascii.
+ENV PYTHONIOENCODING="UTF-8"
+
 ## Update base image and install prerequisites
 RUN apk add --update git python && \
   rm -rf /var/cache/apk/*


### PR DESCRIPTION
Extracted from https://github.com/linuxserver/docker-couchpotato/blob/master/Dockerfile
